### PR TITLE
fix compatibility with networkx 2+ [fix #7|

### DIFF
--- a/tools/qgepnetwork.py
+++ b/tools/qgepnetwork.py
@@ -126,7 +126,7 @@ class QgepGraphManager(QObject):
             except AttributeError:
                 # TODO Add to problem log
                 pass
-            self.graph.add_node(fid, dict(point=vertex, objType=obj_type, objId=obj_id))
+            self.graph.add_node(fid, point=vertex, objType=obj_type, objId=obj_id)
 
             self.vertexIds[unicode(obj_id)] = fid
 
@@ -154,13 +154,9 @@ class QgepGraphManager(QObject):
                 pt_id1 = self.vertexIds[from_obj_id]
                 pt_id2 = self.vertexIds[to_obj_id]
 
-                props = {
-                    'weight': length,
-                    'feature': feat.id(),
-                    'baseFeature': obj_id,
-                    'objType': obj_type
-                }
-                self.graph.add_edge(pt_id1, pt_id2, props)
+                self.graph.add_edge(pt_id1, pt_id2,
+                                    weight=length, feature=feat.id(),
+                                    baseFeature=obj_id, objType=obj_type)
             except KeyError as e:
                 print e
 


### PR DESCRIPTION
this should be compatible with older version (1.8)

The first changes are for Graph.add_node and add_edge by switching from dict (only 1.8) to keyword arguments (compatible 1.8 and 2+)

See the docs:
* https://networkx.github.io/documentation/networkx-1.8/reference/generated/networkx.Graph.add_edge.html#networkx.Graph.add_edge
* https://networkx.github.io/documentation/stable/reference/classes/generated/networkx.Graph.add_edge.html#networkx.Graph.add_edge

should fix #7 