### PR TITLE
Upstream flowtimes

### DIFF
--- a/src/processing_provider/flow_times_upstream.py
+++ b/src/processing_provider/flow_times_upstream.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+
+"""
+/***************************************************************************
+ QGEP processing provider
+                              -------------------
+        begin                : 18.11.2017
+        copyright            : (C) 2017 by OPENGIS.ch
+        email                : matthias@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+
+import qgis
+from qgis.core import (
+    QgsExpression,
+    QgsExpressionContext,
+    QgsExpressionContextUtils,
+    QgsFeature,
+    QgsFeatureRequest,
+    QgsFeatureSink,
+    QgsField,
+    QgsFields,
+    QgsGeometry,
+    QgsProcessing,
+    QgsProcessingAlgorithm,
+    QgsProcessingContext,
+    QgsProcessingException,
+    QgsProcessingFeedback,
+    QgsProcessingParameterFeatureSink,
+    QgsProcessingParameterVectorLayer,
+    QgsProcessingParameterExpression,
+    QgsProcessingParameterField,
+    QgsWkbTypes,
+    NULL
+)
+
+from .qgep_algorithm import QgepAlgorithm
+from ..tools.qgepnetwork import QgepGraphManager
+
+from PyQt5.QtCore import QCoreApplication, QVariant
+
+__author__ = 'Denis Rouzaud'
+__date__ = '2018-07-19'
+__copyright__ = '(C) 2018 by OPENGIS.ch'
+
+# This will get replaced with a git SHA1 when you do a git archive
+
+__revision__ = '$Format:%H$'
+
+
+class FlowTimesUpstreamAlgorithm(QgepAlgorithm):
+    """
+    """
+
+    REACH_LAYER = 'REACH_LAYER'
+    WASTEWATER_NODE_LAYER= 'WASTEWATER_NODE_LAYER'
+    FLOWTIMES_EXPRESSION = 'FLOWTIMES_EXPRESSION'
+    REACH_PK_NAME = 'REACH_PK_NAME'
+    NODE_PK_NAME = 'NODE_PK_NAME'
+    NODE_FROM_FK_NAME = 'NODE_FROM_FK_NAME'
+    NODE_TO_FK_NAME = 'NODE_TO_FK_NAME'
+
+
+    OUTPUT = "OUTPUT"
+
+    def name(self):
+        return 'qgep_flow_times_upstream'
+
+    def displayName(self):
+        return self.tr('Flow times upstream')
+
+    def initAlgorithm(self, config=None):
+        """Here we define the inputs and output of the algorithm, along
+        with some other properties.
+        """
+
+        # The parameters
+        description = self.tr('Reach layer')
+        self.addParameter(QgsProcessingParameterVectorLayer(self.REACH_LAYER, description=description,
+                                                            types=[QgsProcessing.TypeVectorLine], defaultValue='vw_qgep_reach'))
+        description = self.tr('Wastewater node layer')
+        self.addParameter(QgsProcessingParameterVectorLayer(self.WASTEWATER_NODE_LAYER, description=description,
+                                                            types=[QgsProcessing.TypeVector], defaultValue='vw_wastewater_node'))
+        description = self.tr('Flow times expression')
+        self.addParameter(QgsProcessingParameterExpression(self.FLOWTIMES_EXPRESSION, description=description,
+                                                      parentLayerParameterName=self.REACH_LAYER, defaultValue='1'))
+
+        description = self.tr('Primary key field reach')
+        self.addParameter(QgsProcessingParameterField(self.REACH_PK_NAME, description=description,
+                                                      parentLayerParameterName=self.REACH_LAYER, defaultValue='obj_id'))
+
+        description = self.tr('Primary key field node')
+        self.addParameter(QgsProcessingParameterField(self.NODE_PK_NAME, description=description,
+                                                      parentLayerParameterName=self.WASTEWATER_NODE_LAYER, defaultValue='obj_id'))
+
+        description = self.tr('Foreign key field from')
+        self.addParameter(QgsProcessingParameterField(self.NODE_FROM_FK_NAME, description=description,
+                                                           parentLayerParameterName=self.REACH_LAYER,
+                                                           defaultValue='rp_from_fk_wastewater_networkelement'))
+
+        description = self.tr('Foreign key field to')
+        self.addParameter(QgsProcessingParameterField(self.NODE_TO_FK_NAME, description=description,
+                                                           parentLayerParameterName=self.REACH_LAYER,
+                                                           defaultValue='rp_to_fk_wastewater_networkelement'))
+
+        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT,
+                                                            self.tr('Flow times')))
+
+    def processAlgorithm(self, parameters, context: QgsProcessingContext, feedback: QgsProcessingFeedback):
+        """Here is where the processing itself takes place."""
+
+        feedback.setProgress(0)
+
+        # init params
+        reach_layer = self.parameterAsVectorLayer(parameters, self.REACH_LAYER, context)
+        wastewater_node_layer = self.parameterAsVectorLayer(parameters, self.WASTEWATER_NODE_LAYER, context)
+        flow_time_expression = self.parameterAsExpression(parameters, self.FLOWTIMES_EXPRESSION, context)
+        reach_pk_name = self.parameterAsFields(parameters, self.REACH_PK_NAME, context)[0]
+        node_pk_name = self.parameterAsFields(parameters, self.NODE_PK_NAME, context)[0]
+        node_from_fk_name = self.parameterAsFields(parameters, self.NODE_FROM_FK_NAME, context)[0]
+        node_to_fk_name = self.parameterAsFields(parameters, self.NODE_TO_FK_NAME, context)[0]
+
+        # create feature sink
+        fields = wastewater_node_layer.fields()
+        fields.append(QgsField('flow_time', QVariant.Double))
+        (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context, fields,
+                                               QgsWkbTypes.Point, reach_layer.sourceCrs())
+        if sink is None:
+            raise QgsProcessingException(self.invalidSinkError(parameters, self.OUTPUT))
+
+        feature_count = reach_layer.featureCount()
+
+        reaches = dict()
+
+        expression = QgsExpression(flow_time_expression)
+        context = QgsExpressionContext(QgsExpressionContextUtils.globalProjectLayerScopes(reach_layer))
+        expression.prepare(context)
+
+        for reach in reach_layer.getFeatures(QgsFeatureRequest()):
+            context.setFeature(reach)
+            flow_time = expression.evaluate(context)
+            reaches[reach[node_from_fk_name]] = (reach[node_from_fk_name], reach[node_to_fk_name], flow_time)
+
+        qgis.reaches = reaches
+
+        all_nodes = dict()
+
+        current_feature = 0
+        for node in wastewater_node_layer.getFeatures():
+            time = 0.0
+
+            from_node_id = node[node_pk_name]
+            start_node_id = from_node_id
+
+            processed_nodes = []
+            while from_node_id in reaches.keys():
+                if from_node_id in processed_nodes:
+                    feedback.reportError('Loop detected with nodes {}'.format(processed_nodes))
+                    break
+                current_reach = reaches[from_node_id]
+                to_node_id = current_reach[1]
+                time += current_reach[2]
+                processed_nodes.append(from_node_id)
+                from_node_id = to_node_id
+
+            current_feature += 1
+
+            new_node = QgsFeature(node)
+            new_node.setFields(fields)
+            new_node['flow_time'] = time
+
+            sink.addFeature(new_node, QgsFeatureSink.FastInsert)
+            feedback.setProgress(current_feature/feature_count * 100)
+
+        return {self.OUTPUT: dest_id}

--- a/src/processing_provider/provider.py
+++ b/src/processing_provider/provider.py
@@ -22,6 +22,7 @@
 from qgis.core import QgsProcessingProvider
 from .snap_reach import SnapReachAlgorithm
 from .flow_times import FlowTimesAlgorithm
+from .flow_times_upstream import FlowTimesUpstreamAlgorithm
 from .change_reach_direction import ChangeReachDirection
 
 from PyQt5.QtGui import QIcon
@@ -49,7 +50,7 @@ class QgepProcessingProvider(QgsProcessingProvider):
             alg.provider = self
 
     def getAlgs(self):
-        algs = [SnapReachAlgorithm(), FlowTimesAlgorithm(), ChangeReachDirection()]
+        algs = [SnapReachAlgorithm(), FlowTimesAlgorithm(), FlowTimesUpstreamAlgorithm(), ChangeReachDirection()]
         return algs
 
     def id(self):

--- a/src/processing_provider/provider.py
+++ b/src/processing_provider/provider.py
@@ -22,7 +22,7 @@
 from qgis.core import QgsProcessingProvider
 from .snap_reach import SnapReachAlgorithm
 from .flow_times import FlowTimesAlgorithm
-from .flow_times_upstream import FlowTimesUpstreamAlgorithm
+from .sum_up_upstream import SumUpUpstreamAlgorithm
 from .change_reach_direction import ChangeReachDirection
 
 from PyQt5.QtGui import QIcon
@@ -45,12 +45,12 @@ class QgepProcessingProvider(QgsProcessingProvider):
         self.activate = True
 
         # Load algorithms
-        self.alglist = [SnapReachAlgorithm(), FlowTimesAlgorithm(), ChangeReachDirection()]
+        self.alglist = [SnapReachAlgorithm(), FlowTimesAlgorithm(), ChangeReachDirection(), SumUpUpstreamAlgorithm()]
         for alg in self.alglist:
             alg.provider = self
 
     def getAlgs(self):
-        algs = [SnapReachAlgorithm(), FlowTimesAlgorithm(), FlowTimesUpstreamAlgorithm(), ChangeReachDirection()]
+        algs = [SnapReachAlgorithm(), FlowTimesAlgorithm(), SumUpUpstreamAlgorithm(), ChangeReachDirection()]
         return algs
 
     def id(self):

--- a/src/processing_provider/sum_up_upstream.py
+++ b/src/processing_provider/sum_up_upstream.py
@@ -251,7 +251,7 @@ class SumUpUpstreamAlgorithm(QgepAlgorithm):
 
         while node_id in reaches_by_from_node.keys() or node_id in reaches_by_id.keys():
             if node_id in calculated_values:
-                return calculated_values[node_id]
+                return calculated_values[node_id] + time
             if node_id in processed_nodes:
                 # feedback.reportError(self.tr('Loop at node: {}'.format(node_id)))
                 loop_nodes.append(node_id)

--- a/src/processing_provider/sum_up_upstream.py
+++ b/src/processing_provider/sum_up_upstream.py
@@ -219,7 +219,7 @@ class SumUpUpstreamAlgorithm(QgepAlgorithm):
             times = []
             if from_node_id in reaches_by_from_node.keys():
                 for reach in reaches_by_from_node[from_node_id]:
-                    times.append(self.calculate_branch(reach, reaches_by_from_node, reaches_by_id, processed_nodes, calculated_values, aggregate_method, loop_nodes, feedback))
+                    times.append(self.calculate_branch(reach, reaches_by_from_node, reaches_by_id, list(processed_nodes), calculated_values, aggregate_method, loop_nodes, feedback))
 
             if times:
                 time = aggregate_method(times)
@@ -283,7 +283,7 @@ class SumUpUpstreamAlgorithm(QgepAlgorithm):
                     # Branching occurred: calculate every possible path and aggregate all values
                     times = []
                     for reach in current_reaches:
-                        times.append(self.calculate_branch(reach, reaches_by_from_node, reaches_by_id, processed_nodes, calculated_values, aggregate_method, loop_nodes, feedback))
+                        times.append(self.calculate_branch(reach, reaches_by_from_node, reaches_by_id, list(processed_nodes), calculated_values, aggregate_method, loop_nodes, feedback))
 
                     if times:
                         time += aggregate_method(times)

--- a/src/processing_provider/sum_up_upstream.py
+++ b/src/processing_provider/sum_up_upstream.py
@@ -268,7 +268,7 @@ class SumUpUpstreamAlgorithm(QgepAlgorithm):
                 offset = reach.geometry.lineLocatePoint(QgsGeometry(previous_reach.geometry.constGet().endPoint()))
                 length = reach.geometry.length()
                 remaining_part = 1-offset/length
-                feedback.pushInfo('Length: {} Offset: {} Part: {}'.format(length, offset, remaining_part, reach.value * remaining_part))
+                # feedback.pushInfo('Length: {} Offset: {} Part: {}'.format(length, offset, remaining_part, reach.value * remaining_part))
                 time += reach.value * remaining_part
                 node_id = reach.to_id
             else:

--- a/src/processing_provider/sum_up_upstream.py
+++ b/src/processing_provider/sum_up_upstream.py
@@ -36,6 +36,7 @@ from qgis.core import (
     QgsProcessingContext,
     QgsProcessingException,
     QgsProcessingFeedback,
+    QgsProcessingParameterDefinition,
     QgsProcessingParameterFeatureSink,
     QgsProcessingParameterVectorLayer,
     QgsProcessingParameterExpression,
@@ -49,8 +50,8 @@ from ..tools.qgepnetwork import QgepGraphManager
 
 from PyQt5.QtCore import QCoreApplication, QVariant
 
-__author__ = 'Denis Rouzaud'
-__date__ = '2018-07-19'
+__author__ = 'Matthias Kuhn'
+__date__ = '2019-04-09'
 __copyright__ = '(C) 2018 by OPENGIS.ch'
 
 # This will get replaced with a git SHA1 when you do a git archive
@@ -58,13 +59,13 @@ __copyright__ = '(C) 2018 by OPENGIS.ch'
 __revision__ = '$Format:%H$'
 
 
-class FlowTimesUpstreamAlgorithm(QgepAlgorithm):
+class SumUpUpstreamAlgorithm(QgepAlgorithm):
     """
     """
 
     REACH_LAYER = 'REACH_LAYER'
     WASTEWATER_NODE_LAYER= 'WASTEWATER_NODE_LAYER'
-    FLOWTIMES_EXPRESSION = 'FLOWTIMES_EXPRESSION'
+    VALUE_EXPRESSION = 'VALUE_EXPRESSION'
     REACH_PK_NAME = 'REACH_PK_NAME'
     NODE_PK_NAME = 'NODE_PK_NAME'
     NODE_FROM_FK_NAME = 'NODE_FROM_FK_NAME'
@@ -74,10 +75,10 @@ class FlowTimesUpstreamAlgorithm(QgepAlgorithm):
     OUTPUT = "OUTPUT"
 
     def name(self):
-        return 'qgep_flow_times_upstream'
+        return 'qgep_values_upstream'
 
     def displayName(self):
-        return self.tr('Flow times upstream')
+        return self.tr('Sum up upstream')
 
     def initAlgorithm(self, config=None):
         """Here we define the inputs and output of the algorithm, along
@@ -85,36 +86,41 @@ class FlowTimesUpstreamAlgorithm(QgepAlgorithm):
         """
 
         # The parameters
-        description = self.tr('Reach layer')
-        self.addParameter(QgsProcessingParameterVectorLayer(self.REACH_LAYER, description=description,
-                                                            types=[QgsProcessing.TypeVectorLine], defaultValue='vw_qgep_reach'))
-        description = self.tr('Wastewater node layer')
-        self.addParameter(QgsProcessingParameterVectorLayer(self.WASTEWATER_NODE_LAYER, description=description,
-                                                            types=[QgsProcessing.TypeVector], defaultValue='vw_wastewater_node'))
-        description = self.tr('Flow times expression')
-        self.addParameter(QgsProcessingParameterExpression(self.FLOWTIMES_EXPRESSION, description=description,
-                                                      parentLayerParameterName=self.REACH_LAYER, defaultValue='1'))
+        description = self.tr('Source Value Expression')
+        self.addParameter(QgsProcessingParameterExpression(self.VALUE_EXPRESSION, description=description,
+                                                      parentLayerParameterName=self.REACH_LAYER))
 
-        description = self.tr('Primary key field reach')
-        self.addParameter(QgsProcessingParameterField(self.REACH_PK_NAME, description=description,
+        description = self.tr('Reach Layer')
+        self.addAdvancedParameter(QgsProcessingParameterVectorLayer(self.REACH_LAYER, description=description,
+                                                            types=[QgsProcessing.TypeVectorLine], defaultValue='vw_qgep_reach'))
+        description = self.tr('Wastewater Node Layer')
+        self.addAdvancedParameter(QgsProcessingParameterVectorLayer(self.WASTEWATER_NODE_LAYER, description=description,
+                                                            types=[QgsProcessing.TypeVector], defaultValue='vw_wastewater_node'))
+
+        description = self.tr('Primary Key Field Reach')
+        self.addAdvancedParameter(QgsProcessingParameterField(self.REACH_PK_NAME, description=description,
                                                       parentLayerParameterName=self.REACH_LAYER, defaultValue='obj_id'))
 
-        description = self.tr('Primary key field node')
-        self.addParameter(QgsProcessingParameterField(self.NODE_PK_NAME, description=description,
+        description = self.tr('Primary Key Field Node')
+        self.addAdvancedParameter(QgsProcessingParameterField(self.NODE_PK_NAME, description=description,
                                                       parentLayerParameterName=self.WASTEWATER_NODE_LAYER, defaultValue='obj_id'))
 
-        description = self.tr('Foreign key field from')
-        self.addParameter(QgsProcessingParameterField(self.NODE_FROM_FK_NAME, description=description,
+        description = self.tr('Foreign Key Field From')
+        self.addAdvancedParameter(QgsProcessingParameterField(self.NODE_FROM_FK_NAME, description=description,
                                                            parentLayerParameterName=self.REACH_LAYER,
                                                            defaultValue='rp_from_fk_wastewater_networkelement'))
 
-        description = self.tr('Foreign key field to')
-        self.addParameter(QgsProcessingParameterField(self.NODE_TO_FK_NAME, description=description,
+        description = self.tr('Foreign Key Field To')
+        self.addAdvancedParameter(QgsProcessingParameterField(self.NODE_TO_FK_NAME, description=description,
                                                            parentLayerParameterName=self.REACH_LAYER,
                                                            defaultValue='rp_to_fk_wastewater_networkelement'))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT,
-                                                            self.tr('Flow times')))
+                                                            self.tr('Summed up')))
+
+    def addAdvancedParameter(self, parameter):
+        parameter.setFlags(parameter.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(parameter)
 
     def processAlgorithm(self, parameters, context: QgsProcessingContext, feedback: QgsProcessingFeedback):
         """Here is where the processing itself takes place."""
@@ -124,7 +130,7 @@ class FlowTimesUpstreamAlgorithm(QgepAlgorithm):
         # init params
         reach_layer = self.parameterAsVectorLayer(parameters, self.REACH_LAYER, context)
         wastewater_node_layer = self.parameterAsVectorLayer(parameters, self.WASTEWATER_NODE_LAYER, context)
-        flow_time_expression = self.parameterAsExpression(parameters, self.FLOWTIMES_EXPRESSION, context)
+        value_expression = self.parameterAsExpression(parameters, self.VALUE_EXPRESSION, context)
         reach_pk_name = self.parameterAsFields(parameters, self.REACH_PK_NAME, context)[0]
         node_pk_name = self.parameterAsFields(parameters, self.NODE_PK_NAME, context)[0]
         node_from_fk_name = self.parameterAsFields(parameters, self.NODE_FROM_FK_NAME, context)[0]
@@ -132,7 +138,7 @@ class FlowTimesUpstreamAlgorithm(QgepAlgorithm):
 
         # create feature sink
         fields = wastewater_node_layer.fields()
-        fields.append(QgsField('flow_time', QVariant.Double))
+        fields.append(QgsField('value', QVariant.Double))
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context, fields,
                                                QgsWkbTypes.Point, reach_layer.sourceCrs())
         if sink is None:
@@ -142,14 +148,14 @@ class FlowTimesUpstreamAlgorithm(QgepAlgorithm):
 
         reaches = dict()
 
-        expression = QgsExpression(flow_time_expression)
+        expression = QgsExpression(value_expression)
         context = QgsExpressionContext(QgsExpressionContextUtils.globalProjectLayerScopes(reach_layer))
         expression.prepare(context)
 
         for reach in reach_layer.getFeatures(QgsFeatureRequest()):
             context.setFeature(reach)
-            flow_time = expression.evaluate(context)
-            reaches[reach[node_from_fk_name]] = (reach[node_from_fk_name], reach[node_to_fk_name], flow_time)
+            value = expression.evaluate(context)
+            reaches[reach[node_from_fk_name]] = (reach[node_from_fk_name], reach[node_to_fk_name], value)
 
         qgis.reaches = reaches
 
@@ -177,7 +183,7 @@ class FlowTimesUpstreamAlgorithm(QgepAlgorithm):
 
             new_node = QgsFeature(node)
             new_node.setFields(fields)
-            new_node['flow_time'] = time
+            new_node['value'] = time
 
             sink.addFeature(new_node, QgsFeatureSink.FastInsert)
             feedback.setProgress(current_feature/feature_count * 100)

--- a/src/processing_provider/sum_up_upstream.py
+++ b/src/processing_provider/sum_up_upstream.py
@@ -104,11 +104,15 @@ class SumUpUpstreamAlgorithm(QgepAlgorithm):
         self.addParameter(QgsProcessingParameterEnum(self.BRANCH_BEHAVIOR, description=description,
                                                       options=[self.tr('Minimum'), self.tr('Maximum'), self.tr('Average')]))
 
+        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT,
+                                                            self.tr('Summed up')))
+
         description = self.tr('Create a layer with nodes in loops')
         self.addAdvancedParameter(QgsProcessingParameterBoolean(self.CREATE_LOOP_LAYER, description=description,
                                                                     defaultValue=False))
-        self.addParameter(QgsProcessingParameterFeatureSink(self.LOOP_OUTPUT,
-                                                            self.tr('Loop nodes')))
+
+        self.addAdvancedParameter(QgsProcessingParameterFeatureSink(self.LOOP_OUTPUT,
+                                                            self.tr('Loop nodes (Only created if "Crate a layer with nodes in loops" option is activated)'), optional=True))
         description = self.tr('Reach Layer')
         self.addAdvancedParameter(QgsProcessingParameterVectorLayer(self.REACH_LAYER, description=description,
                                                             types=[QgsProcessing.TypeVectorLine], defaultValue='vw_qgep_reach'))
@@ -133,9 +137,6 @@ class SumUpUpstreamAlgorithm(QgepAlgorithm):
         self.addAdvancedParameter(QgsProcessingParameterField(self.NODE_TO_FK_NAME, description=description,
                                                            parentLayerParameterName=self.REACH_LAYER,
                                                            defaultValue='rp_to_fk_wastewater_networkelement'))
-
-        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT,
-                                                            self.tr('Summed up')))
 
     def addAdvancedParameter(self, parameter):
         parameter.setFlags(parameter.flags() | QgsProcessingParameterDefinition.FlagAdvanced)


### PR DESCRIPTION
This adds a new processing algorithm to sum up flowtimes - or other values - upstream.

* Any field on the "reach" layer can be used as field for the calculation. As well as derived values (see `$length` example below).
* The branching behavior. If different routes are available, the behavior can be specified (i.e. minimum, maximum and average
* Loop detection with reporting (if there is a loop in a network, it's unclear how many rounds each drop of water takes until it leaves it ;) )
* Further parameters like input layers etc. are autoconfigured but can be fine tuned under "advanced" if desired.

![Screenshot from 2019-06-20 12-44-16](https://user-images.githubusercontent.com/588407/59843601-30b43680-9359-11e9-9ba8-ffa3007dc9b4.png)

Note: "sum" as additional branching aggregate could also be interesting (total amount of network meters up to a certain point), let me know if you think it's useful) please let me know if you think it's useful
