### PR TITLE
fix #546 : Freeze when digitizing reach with wizard

### DIFF
--- a/qgepplugin/tools/qgepmaptooladdfeature.py
+++ b/qgepplugin/tools/qgepmaptooladdfeature.py
@@ -65,6 +65,7 @@ class QgepRubberBand3D(QgsRubberBand):
     def addPoint3D(self, point):
         assert type(point) == QgsPoint
         QgsRubberBand.addPoint(self, QgsPointXY(point.x(), point.y()))
+        # Workaround crash with QGIS 3.10.2 (https://github.com/qgis/QGIS/issues/34557)
         new_point = QgsPoint(point.x(), point.y(), point.z(), point.m(), point.wkbType())
         self.points.append(new_point)
 

--- a/qgepplugin/tools/qgepmaptooladdfeature.py
+++ b/qgepplugin/tools/qgepmaptooladdfeature.py
@@ -65,7 +65,8 @@ class QgepRubberBand3D(QgsRubberBand):
     def addPoint3D(self, point):
         assert type(point) == QgsPoint
         QgsRubberBand.addPoint(self, QgsPointXY(point.x(), point.y()))
-        self.points.append(QgsPoint(point))
+        new_point = QgsPoint(point.x(), point.y(), point.z(), point.m(), point.wkbType())
+        self.points.append(new_point)
 
     def reset3D(self):
         QgsRubberBand.reset(self)


### PR DESCRIPTION
Fix QGEP/QGEP#546

A workaround for an underlying bug in QGIS which can be reproduced like this (in the console) :
```
point_a = QgsPoint(10,20)
point_b = QgsPoint(point_a)
```
It appears the `QgsPoint(QgsPoint other)` constructor doesn't exist, but that's really error prone, and shouldn't crash anyways...