### PR TITLE
Fix plugin with python >= 3.8

### DIFF
--- a/qgepplugin/tools/qgepnetwork.py
+++ b/qgepplugin/tools/qgepnetwork.py
@@ -198,7 +198,7 @@ class QgepGraphManager(QObject):
         """
         spenttime = 0
         if self.timings:
-            spenttime = time.clock() - self.timings[-1][1]
+            spenttime = time.process_time() - self.timings[-1][1]
         self.timings.append((name, spenttime))
 
     # Creates a network graph


### PR DESCRIPTION
Error:

```
AttributeError: module 'time' has no attribute 'clock'
```

Reference https://bugs.python.org/issue36895