### PR TITLE
2021 06 datamodeltool followup

### DIFF
--- a/qgepplugin/gui/qgepdatamodeldialog.py
+++ b/qgepplugin/gui/qgepdatamodeldialog.py
@@ -34,7 +34,7 @@ import zipfile
 import pkg_resources
 import psycopg2
 from qgis.core import Qgis, QgsMessageLog, QgsNetworkAccessManager, QgsProject
-from qgis.PyQt.QtCore import QFile, QIODevice, QUrl
+from qgis.PyQt.QtCore import QFile, QIODevice, QSettings, QUrl
 from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
 from qgis.PyQt.QtWidgets import (
     QApplication,
@@ -54,11 +54,16 @@ from ..utils import get_ui_class
 LATEST_RELEASE = "1.5.5"
 
 # Allow to choose which releases can be installed
-# (not so useful... but may want allow picking master for pre-releases)
 AVAILABLE_RELEASES = {
-    # 'master': 'https://github.com/QGEP/datamodel/archive/master.zip',  # TODO : if we expose this here, we should put a big red warning and not take it default
     LATEST_RELEASE: f"https://github.com/QGEP/datamodel/archive/{LATEST_RELEASE}.zip",
 }
+if QSettings().value("/QGEP/DeveloperMode", False):
+    AVAILABLE_RELEASES.update(
+        {
+            "master": "https://github.com/QGEP/datamodel/archive/master.zip",
+        }
+    )
+
 # Allows to pick which QGIS project matches the version (will take the biggest <= match)
 DATAMODEL_QGEP_VERSIONS = {
     "1.5.5": "v9.0",
@@ -406,10 +411,18 @@ class QgepDatamodelInitToolDialog(QDialog, get_ui_class("qgepdatamodeldialog.ui"
         check = requirements_exists and deltas_exists
 
         if check:
-            self.releaseCheckLabel.setText("ok")
-            self.releaseCheckLabel.setStyleSheet(
-                "color: rgb(0, 170, 0);\nfont-weight: bold;"
-            )
+            if self.version == "master":
+                self.releaseCheckLabel.setText(
+                    "DEV RELEASE - DO NOT USE FOR PRODUCTION"
+                )
+                self.releaseCheckLabel.setStyleSheet(
+                    "color: rgb(170, 0, 0);\nfont-weight: bold;"
+                )
+            else:
+                self.releaseCheckLabel.setText("ok")
+                self.releaseCheckLabel.setStyleSheet(
+                    "color: rgb(0, 170, 0);\nfont-weight: bold;"
+                )
         else:
             self.releaseCheckLabel.setText("not found")
             self.releaseCheckLabel.setStyleSheet(

--- a/qgepplugin/gui/qgepsettingsdialog.py
+++ b/qgepplugin/gui/qgepsettingsdialog.py
@@ -119,8 +119,8 @@ class QgepSettingsDialog(QDialog, DIALOG_UI):
         else:
             self.settings.remove("/QGEP/SvgProfilePath")
 
-        self.settings.setValue("/QGEP/DeveloperMode", self.mCbDevelMode.checkState())
-        self.settings.setValue("/QGEP/AdminMode", self.mCbAdminMode.checkState())
+        self.settings.setValue("/QGEP/DeveloperMode", self.mCbDevelMode.isChecked())
+        self.settings.setValue("/QGEP/AdminMode", self.mCbAdminMode.isChecked())
 
         # Logging
         if hasattr(qgeplogger, "qgepFileHandler"):

--- a/qgepplugin/ui/qgepsettingsdialog.ui
+++ b/qgepplugin/ui/qgepsettingsdialog.ui
@@ -171,7 +171,7 @@
           <string>Enables developer tools on the profile widget. Reload and Inspect options are shown. The dock needs to be reopened.</string>
          </property>
          <property name="text">
-          <string>Developer mode</string>
+          <string>Developer mode (restart required)</string>
          </property>
         </widget>
        </item>
@@ -181,7 +181,7 @@
           <string>Enables the datamodel tool. The plugin needs to be reloaded.</string>
          </property>
          <property name="text">
-          <string>Admin mode</string>
+          <string>Admin mode (restart required)</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This allows to get the current master version of the datamodel from the datamodel tool when dev mode is enabled in the QGEP settings.

This is meant to make it easier for testers to test upcoming datamodels.

It also shows a warning, as this makes it easy to cause serious issues to a production database (apply deltas that are not yet released)

![image](https://user-images.githubusercontent.com/1894106/123405179-da160e80-d5a9-11eb-814b-473a5a88049a.png)
