### PR TITLE
fix Transifex resource fetching

### DIFF
--- a/.qgis-plugin-ci
+++ b/.qgis-plugin-ci
@@ -2,4 +2,4 @@ plugin_path: qgepplugin
 github_organization_slug: qgep
 project_slug: qgepplugin
 transifex_project: QGEP
-transifex_resource: qgepplugin
+transifex_resource: qgep-plugin

--- a/.tx/config
+++ b/.tx/config
@@ -10,7 +10,7 @@ trans.fr = i18n/qgep-project_fr.ts
 trans.it = i18n/qgep-project_it.ts
 type = QT
 
-[QGEP.qgepplugin]
+[QGEP.qgep-plugin]
 source_file = i18n/qgepplugin_en.ts
 file_filter = i18n/qgepplugin_<lang>.ts
 source_lang = en


### PR DESCRIPTION
there were 2 resources similarly named (`qgepplugin` and `qgeplugin-js`) and apparently the SDK fetches both when you try to get `qgepplugin`.
I've renamed the first one to `qgep-plugin`.