### PR TITLE
fix #810: fix datamodel tool urls

### DIFF
--- a/qgepplugin/gui/qgepdatamodeldialog.py
+++ b/qgepplugin/gui/qgepdatamodeldialog.py
@@ -60,7 +60,6 @@ from ..utils import get_ui_class
 # Allow to choose which releases can be installed
 AVAILABLE_RELEASES = {
     "1.6.0": f"https://github.com/QGEP/datamodel/archive/1.6.0.zip",
-    "1.5.6": f"https://github.com/QGEP/datamodel/archive/1.5.6.zip",
 }
 if QSettings().value("/QGEP/DeveloperMode", False, type=bool):
     AVAILABLE_RELEASES.update(


### PR DESCRIPTION
fixes for https://github.com/QGEP/QGEP/issues/810 (the 1.5.6 part)

remove the link to 1.5.6 release, anyway restoring an old release from the datamodel tool is not a good idea as you'd be using a potentially incompatible version